### PR TITLE
Shaygeko/updates collector service

### DIFF
--- a/backend/src/api/leetcode.ts
+++ b/backend/src/api/leetcode.ts
@@ -39,25 +39,23 @@ export async function getSubmitStats(userId: string) {
     }
 }
 
-export async function getLatestSubmits(userId: string) {
+export async function getLatestAcceptedSubmits(userId: string, limit: number = 10) {
   if(!isValidUsername(userId)) return;
   try {
     // Make the GraphQL request
     const response = await axios.post('https://leetcode.com/graphql', {
       query: `
       {     
-        recentSubmissionList(username: "${userId}") {
+        recentAcSubmissionList(username: "${userId}", limit: ${limit}) {
           title
           titleSlug
           timestamp
-          statusDisplay
           lang
-          __typename
           }
       }
       `
     });
-    return response.data.data.recentSubmissionList;
+    return response.data.data.recentAcSubmissionList;
   } catch (error) {
     console.error(`Error fetching data for user ID ${userId}:`, error);
   }

--- a/backend/src/events/UserUpdateEventEmitter.ts
+++ b/backend/src/events/UserUpdateEventEmitter.ts
@@ -1,0 +1,35 @@
+import EventEmitter from 'events';
+
+export interface UpdateEventData {
+    username: string,
+    platform: string,
+    problemTitle: string,
+    problemTitleSlug: string, // for "Three sum" titleSlug is "three-sum", needed to craft problem url
+    timestamp: number
+}
+export class UserUpdateEventEmitter{
+    private eventEmitter: EventEmitter;
+    private readonly EVENT_NAME = "user-update"
+    constructor() {
+        this.eventEmitter = new EventEmitter();
+        //TODO: setup things for GCP Pub/Sub
+
+        this.eventEmitter.on(this.EVENT_NAME, (updateData) => {
+            console.log("Update event fired", updateData)
+
+            /*
+            TODO: 
+                1) store updateEvent in postgres db
+                2) send the event to google pubsub (if we have time) - alternatively send on emit
+            */
+        })
+    }
+  
+    emit(data : UpdateEventData) {
+        this.eventEmitter.emit(this.EVENT_NAME, data);
+
+        // TODO: send to pub sub?
+    }
+}
+
+export const userUpdateEventEmitter = new UserUpdateEventEmitter();

--- a/backend/src/routes/users/users-route.ts
+++ b/backend/src/routes/users/users-route.ts
@@ -5,7 +5,7 @@ import { getUserIDs, addUserID } from '../../model/users';
 import { User } from '../../model/schemas/userSchema';
 import { UserNameNotFoundError } from '../../errors/username-not-found-error';
 import { getSubmissionStats } from '../../api/vjudge';
-import { getLatestSubmits, getSubmitStats } from '../../api/leetcode';
+import { getLatestAcceptedSubmits, getSubmitStats } from '../../api/leetcode';
 import multer from 'multer';
 
 const upload = multer({ dest: 'uploads/' });
@@ -31,7 +31,7 @@ router.get('/:username/latestSubmits', [
   } else {
 
     const leetcodeUsername = userData.leetcode.username;
-    const submitStats = await getLatestSubmits(leetcodeUsername);
+    const submitStats = await getLatestAcceptedSubmits(leetcodeUsername);
   
     if(!submitStats){
       res.status(404).send("User not found on leetcode");

--- a/backend/src/scheduler/scheduler.ts
+++ b/backend/src/scheduler/scheduler.ts
@@ -1,12 +1,19 @@
 import { CronJob } from "cron";
-import { getSubmitStats } from "../api/leetcode";
-import { getUserIDs } from "../model/users";
+import { User } from "../model/schemas/userSchema";
+import { getUpdates } from "../services/UpdatesCollectorService";
 
 
-const job = new CronJob('*/2 * * * *', () => {
-    for (const userId of getUserIDs()) {
-      getSubmitStats(userId);
-    }
+const job = new CronJob('*/2 * * * *', async () => {
+    const userData = await User.find({}, {
+      _id:1,
+      username:1,
+    })
+
+    await Promise.all(userData.map(u => {
+      // should probably change this to use id
+      getUpdates(u.username!!)
+    }))
+
   });
 
 export const startJob = () => job.start();

--- a/backend/src/services/UpdatesCollectorService.ts
+++ b/backend/src/services/UpdatesCollectorService.ts
@@ -1,0 +1,62 @@
+import { getLatestAcceptedSubmits, getSubmitStats } from "../api/leetcode";
+import { UserNameNotFoundError } from "../errors/username-not-found-error";
+import { UpdateEventData, userUpdateEventEmitter } from "../events/UserUpdateEventEmitter";
+import { User } from "../model/schemas/userSchema";
+
+export async function getLeetcodeUpdates(username: string) {
+    const u = await User.findOne({ username: username });
+
+    if (!u) {
+        throw new UserNameNotFoundError(username);
+    } else {
+        const updates = await (async () => {
+            if (u.leetcode?.username) {
+                const newData = await getSubmitStats(u.leetcode.username);
+
+                // get difference in total solved count from old data and new
+                const solvedDifference = newData.submitStats?.acSubmissionNum[0].count!! - u.leetcode.submitStats?.acSubmissionNum[0].count!!;
+                // if it changed (note: cannot decrease), query for <n=difference> last solved questions
+                if (solvedDifference > 0) {
+                    console.log(`User ${u.username} has solved something new on leetcode. (username: ${u.leetcode.username})`)
+                    const updates = await getLatestAcceptedSubmits(u.leetcode.username, solvedDifference);
+
+                    // once we have a list of problems that were solved since last check, emit an event for each of them
+                    updates.forEach((upd: any) => {
+                        const updateData: UpdateEventData = {
+                            username: username,
+                            platform: "LEETCODE",
+                            problemTitle: upd.title,
+                            problemTitleSlug: upd.titleSlug,
+                            timestamp: parseInt(upd.timestamp)
+                        }
+                        userUpdateEventEmitter.emit(updateData);
+                    });
+                    return updates;
+                }
+                else {
+                    console.log(`No LeetCode updates for user ${username}`);
+                    return [];
+                }
+            } else return [];
+        })();
+
+        return updates;
+    }
+}
+
+export async function getVjudgeUpdates(username: string) {
+    // TODO: implement
+    return [];
+}
+
+export async function getUpdates(username: string) {
+    const leetcodeUpdatesPromise = getLeetcodeUpdates(username);
+    const vjudgeUpdatesPromise = getVjudgeUpdates(username);
+
+    const leetcodeUpdates = await leetcodeUpdatesPromise;
+    const vjudgeUpdates= await vjudgeUpdatesPromise;
+
+    console.log(leetcodeUpdates);
+
+    return {leetcodeUpdates: leetcodeUpdates, vjudgeUpdates: vjudgeUpdates};
+}


### PR DESCRIPTION
**Adding updates collector service and events**
    
   - **changed leetcode query endpoint to retrieve only for accepted submissions**
    
   - **So far updates collector is for leetcode only**
    Compares local data for user to data on leetcode
    If there are N new problems solved, queries for N latest AC on leetcode for user
    Generates an update event for each of these problems
    Note: timestamp is coming from leetcode, so the events will actually have different times
    
   - Also adding the UserUpdateEventEmitter
    This is where we can have a listener for all updates, and write them to postgres db
    Also from here we can send things go GCP Pub/Sub so that anyone listening could also receive an event

  -  Using collector in scheduler and test endpoint
 
 Endpoint showing a new problem on leetcode I solved today (the difference between db data and leetcode data):
![updatesCollectorService](https://github.com/dannyl1u/codegram/assets/25514702/1f1158b5-41e6-4662-937e-326fedcc0bb8)
